### PR TITLE
fixes #4: Compile admin pages when building plugin

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -47,8 +47,9 @@ GoJara Plugin Changelog
 <p><b>2.2.3</b> -- (tbd)</p>
 <ul>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1517'>OF-1517</a>] - Don't require i18n source files for all plugins to be encoded.</li>
-    <li>[<a href='https://issues.igniterealtime.org/browse/OF-1641'>OF-1641</a>] - Ensure all JSP pages have the correct contenti>Type.</li>
+    <li>[<a href='https://issues.igniterealtime.org/browse/OF-1641'>OF-1641</a>] - Ensure all JSP pages have the correct contentType.</li>
     <li>[<a href='https://github.com/igniterealtime/openfire-gojara-plugin/issues/1'>#1</a>] - Fix Maven build</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-gojara-plugin/issues/4'>#4</a>] - Every Gojara Page not Found HTTP ERROR 404</li>
     <li>Minimum Java requirement: 1.8</li>
 </ul>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
-    <!-- Main plugin class -->
-    <class>org.jivesoftware.openfire.plugin.gojara.base.RemoteRosterPlugin
-    </class>
-
-
+    <class>org.jivesoftware.openfire.plugin.gojara.base.RemoteRosterPlugin</class>
     <name>GoJara</name>
     <description>XEP-0321: Remote Roster Management support
     </description>
     <author>Holger Bergunde / Daniel Henninger / Axel-F. Brand</author>
     <version>${project.version}</version>
-    <date>03/23/2018</date>
+    <date>2022-03-23</date>
     <databaseKey>gojara</databaseKey>
     <databaseVersion>1</databaseVersion>
     <minServerVersion>4.0.0</minServerVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
             </plugin>
+            <!-- Compiles the Openfire Admin Console JSP pages. -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jspc-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This fixes an oversight when moving the project to Maven: the admin console pages need to be compiled.